### PR TITLE
Client caching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile 'commons-cli:commons-cli:1.3.1'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'commons-io:commons-io:2.4'
+    compile 'com.google.code.gson:gson:2.3.1'
 }
 
 task wrapper(type: Wrapper) {

--- a/src/main/java/com/neko/UDPServer.java
+++ b/src/main/java/com/neko/UDPServer.java
@@ -1,6 +1,7 @@
 package com.neko;
 
 import static com.neko.msg.NekoOpcode.ERROR;
+import static com.neko.msg.NekoOpcode.LAST_MODIFIED;
 import static com.neko.msg.NekoOpcode.RESULT;
 import static org.apache.commons.io.FileUtils.readFileToString;
 
@@ -210,6 +211,22 @@ public class UDPServer {
         return res;
     }
 
+    private static NekoData handleLastModified(String path) {
+        File file = new File(path);
+        NekoData respond = new NekoData();
+        if (!file.exists()) {
+            respond.setOpcode(ERROR);
+            String errorMessage = path + " does not exists";
+            System.out.println(errorMessage);
+            respond.setError(errorMessage);
+            return respond;
+        }
+
+        respond.setOpcode(LAST_MODIFIED);
+        respond.setLastModified(String.valueOf(file.lastModified()));
+        return respond;
+    }
+
     public static void main(String[] args) {
         AT_MOST_ONE = args.length > 0 && args[0].equals("1");
         DatagramSocket socket = null;
@@ -260,6 +277,9 @@ public class UDPServer {
                             break;
                         case COUNT:
                             respond = handleCount(request.getPath());
+                            break;
+                        case LAST_MODIFIED:
+                            respond = handleLastModified(request.getPath());
                             break;
                         default:
                             // If the operation code is not defined, we just skip this request

--- a/src/main/java/com/neko/UDPServer.java
+++ b/src/main/java/com/neko/UDPServer.java
@@ -42,7 +42,7 @@ public class UDPServer {
 
     private static NekoData handleRead(String path) {
         File file = new File(path);
-        String text = null;
+        String text;
         try {
             text = FileUtils.readFileToString(file);
         } catch (IOException e) {
@@ -56,6 +56,7 @@ public class UDPServer {
         NekoData respond = new NekoData();
         respond.setOpcode(RESULT);
         respond.setText(text);
+        respond.setLastModified(String.valueOf(file.lastModified()));
         return respond;
     }
 

--- a/src/main/java/com/neko/cli/FileMetadata.java
+++ b/src/main/java/com/neko/cli/FileMetadata.java
@@ -1,25 +1,22 @@
 package com.neko.cli;
 
-/**
- * Created by andyccs on 23/3/16.
- */
-public class FileMetadata {
+class FileMetadata {
     private Long lastModified;
     private Long lastValidation;
 
-    public Long getLastModified() {
+    Long getLastModified() {
         return lastModified;
     }
 
-    public void setLastModified(Long lastModified) {
+    void setLastModified(Long lastModified) {
         this.lastModified = lastModified;
     }
 
-    public Long getLastValidation() {
+    Long getLastValidation() {
         return lastValidation;
     }
 
-    public void setLastValidation(Long lastValidation) {
+    void setLastValidation(Long lastValidation) {
         this.lastValidation = lastValidation;
     }
 }

--- a/src/main/java/com/neko/cli/FileMetadata.java
+++ b/src/main/java/com/neko/cli/FileMetadata.java
@@ -1,0 +1,25 @@
+package com.neko.cli;
+
+/**
+ * Created by andyccs on 23/3/16.
+ */
+public class FileMetadata {
+    private Long lastModified;
+    private Long lastValidation;
+
+    public Long getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(Long lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    public Long getLastValidation() {
+        return lastValidation;
+    }
+
+    public void setLastValidation(Long lastValidation) {
+        this.lastValidation = lastValidation;
+    }
+}

--- a/src/main/java/com/neko/cli/Neko.java
+++ b/src/main/java/com/neko/cli/Neko.java
@@ -233,8 +233,7 @@ public class Neko {
 
             if (Objects.equals(cachedFileMetadata.getLastModified(), serverLastModified)) {
                 log.fine("Server file not modified, read from cache");
-
-                cachedFileMetadata.setLastValidation(System.currentTimeMillis());
+                cache.updateLastValidation(filePath, System.currentTimeMillis());
                 String text = cache.read(filePath);
                 log.info(nekoSubstring(offset, length, text));
             } else {

--- a/src/main/java/com/neko/cli/Neko.java
+++ b/src/main/java/com/neko/cli/Neko.java
@@ -3,6 +3,7 @@ package com.neko.cli;
 import static com.neko.msg.NekoOpcode.COPY;
 import static com.neko.msg.NekoOpcode.COUNT;
 import static com.neko.msg.NekoOpcode.INSERT;
+import static com.neko.msg.NekoOpcode.LAST_MODIFIED;
 import static com.neko.msg.NekoOpcode.MONITOR;
 import static com.neko.msg.NekoOpcode.READ;
 
@@ -213,7 +214,7 @@ public class Neko {
             log.fine("File not fresh, read last modified from server");
             // TODO(andyccs): fetch last modified from server efficiently
             NekoData request = new NekoData();
-            request.setOpcode(READ);
+            request.setOpcode(LAST_MODIFIED);
             request.setRequestId(REQUEST_ID_2);
             request.setPath(filePath);
             NekoData respond = sendBytes(request);

--- a/src/main/java/com/neko/cli/Neko.java
+++ b/src/main/java/com/neko/cli/Neko.java
@@ -251,10 +251,10 @@ public class Neko {
         request.setPath(filePath);
 
         NekoData respond = sendBytes(request);
-        String fullText = respond.getText();
-
-        log.info(nekoSubstring(offset, length, fullText));
         log.fine(respond.toString());
+
+        String fullText = respond.getText();
+        log.info(nekoSubstring(offset, length, fullText));
         return respond;
     }
 

--- a/src/main/java/com/neko/cli/Neko.java
+++ b/src/main/java/com/neko/cli/Neko.java
@@ -70,6 +70,12 @@ public class Neko {
             .withType(Integer.class)
             .create();
 
+    private static Option freshnessOption = OptionBuilder.withLongOpt("fresh")
+            .withDescription("the freshness interval of cache")
+            .hasArg()
+            .withType(Long.class)
+            .create();
+
     private static Option help = new Option("h", "help", false, "print this message");
     private static Option debug = new Option("d", "debug", false, "print debug message");
     private static Option verbose = new Option("v", "verbose", false, "print verbose message");
@@ -93,6 +99,7 @@ public class Neko {
 
         readOptions.addOption(readOffsetOption);
         readOptions.addOption(byteOption);
+        readOptions.addOption(freshnessOption);
         readOptions.addOption(portOption);
         readOptions.addOption(debug);
         readOptions.addOption(verbose);
@@ -171,7 +178,6 @@ public class Neko {
         }
     }
 
-    // TODO(andyccs): receive this input from user
     private static long freshnessInterval = 10000L;
 
     private static void read(String[] commandArgs) throws IOException {
@@ -182,6 +188,12 @@ public class Neko {
             CommandLine line = parser.parse(readOptions, commandArgs);
             setLoggerLevel(line);
             setDatagramPort(line);
+
+            if (line.hasOption(freshnessOption.getLongOpt())) {
+                freshnessInterval = Long.parseLong(
+                    line.getOptionValue(freshnessOption.getLongOpt()));
+                log.fine("set freshness interval to " + freshnessInterval);
+            }
 
             String filePath = getFilePath(line.getArgs());
             int offset = Integer.parseInt(line.getOptionValue("o"));
@@ -212,7 +224,6 @@ public class Neko {
             }
 
             log.fine("File not fresh, read last modified from server");
-            // TODO(andyccs): fetch last modified from server efficiently
             NekoData request = new NekoData();
             request.setOpcode(LAST_MODIFIED);
             request.setRequestId(REQUEST_ID_2);

--- a/src/main/java/com/neko/cli/Neko.java
+++ b/src/main/java/com/neko/cli/Neko.java
@@ -71,10 +71,10 @@ public class Neko {
     private static Option debug = new Option("d", "debug", false, "print debug message");
     private static Option verbose = new Option("v", "verbose", false, "print verbose message");
     private static Option portOption = OptionBuilder.withLongOpt("port")
-        .withDescription("client datagram port")
-        .hasArg()
-        .withType(Integer.class)
-        .create();
+            .withDescription("client datagram port")
+            .hasArg()
+            .withType(Integer.class)
+            .create();
 
     private static Options options = new Options();
     private static Options readOptions = new Options();
@@ -129,7 +129,7 @@ public class Neko {
         String[] commandArgs = new String[args.length - 1];
         System.arraycopy(args, 1, commandArgs, 0, commandArgs.length);
 
-        while(true) {
+        while (true) {
             try {
                 switch (command) {
                     case "read":

--- a/src/main/java/com/neko/cli/NekoCache.java
+++ b/src/main/java/com/neko/cli/NekoCache.java
@@ -71,7 +71,7 @@ class NekoCache {
     }
 
     void remove(String filePath) {
-        File cacheFile = new File(filePath);
+        File cacheFile = new File(cacheDirectory + "/" + filePath);
         try {
             FileUtils.forceDelete(cacheFile);
 

--- a/src/main/java/com/neko/cli/NekoCache.java
+++ b/src/main/java/com/neko/cli/NekoCache.java
@@ -3,7 +3,6 @@ package com.neko.cli;
 import static org.apache.commons.io.FileUtils.readFileToString;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/main/java/com/neko/cli/NekoCache.java
+++ b/src/main/java/com/neko/cli/NekoCache.java
@@ -21,12 +21,9 @@ class NekoCache {
 
     private static final String CACHE_DATA_FILE = ".cache_data.json";
 
-    HashMap<String, FileMetadata> caches;
+    private HashMap<String, FileMetadata> caches;
 
     private String cacheDirectory;
-
-    public NekoCache() {
-    }
 
     NekoCache(String cacheDirectory) {
         this.cacheDirectory = cacheDirectory;
@@ -54,10 +51,7 @@ class NekoCache {
         }
     }
 
-    void save(String filePath,
-                     long lastModified,
-                     long lastValidation,
-                     String text) {
+    void save(String filePath, long lastModified, long lastValidation, String text) {
         FileMetadata metadata = new FileMetadata();
         metadata.setLastValidation(lastValidation);
         metadata.setLastModified(lastModified);
@@ -70,35 +64,46 @@ class NekoCache {
         try {
             FileUtils.write(cacheFile, text);
 
-            Gson gson = new Gson();
-            String json = gson.toJson(caches);
-
-            File cacheDataFile = new File(cacheDirectory + "/" + CACHE_DATA_FILE);
-            FileUtils.write(cacheDataFile, json);
+            saveCacheToFile();
         } catch (IOException exception) {
             log.warning(exception.getMessage());
         }
     }
 
     void remove(String filePath) {
+        File cacheFile = new File(filePath);
+        try {
+            FileUtils.forceDelete(cacheFile);
 
+            caches.remove(filePath);
+            saveCacheToFile();
+        } catch (IOException e) {
+            log.warning(e.getMessage());
+        }
     }
 
     FileMetadata readMetadata(String filePath) {
         return caches.get(filePath);
     }
 
-    String read(String filePath, int offset, int length) throws IOException {
+    String read(String filePath) throws IOException {
         if (!exist(filePath)) {
             return null;
         }
 
         File cacheFile = new File(cacheDirectory + "/" + filePath);
-        String text = FileUtils.readFileToString(cacheFile);
-        return text.substring(offset, offset + length);
+        return FileUtils.readFileToString(cacheFile);
     }
 
     boolean exist(String filePath) {
         return caches.containsKey(filePath);
+    }
+
+    private void saveCacheToFile() throws IOException {
+        Gson gson = new Gson();
+        String json = gson.toJson(caches);
+
+        File cacheDataFile = new File(cacheDirectory + "/" + CACHE_DATA_FILE);
+        FileUtils.write(cacheDataFile, json);
     }
 }

--- a/src/main/java/com/neko/cli/NekoCache.java
+++ b/src/main/java/com/neko/cli/NekoCache.java
@@ -69,6 +69,20 @@ class NekoCache {
         }
     }
 
+    void updateLastValidation(String filePath, long lastValidation) {
+        if (!exist(filePath)) {
+            return;
+        }
+        log.fine("update last validation of " + filePath + " to " + lastValidation);
+        FileMetadata metadata = caches.get(filePath);
+        metadata.setLastValidation(lastValidation);
+        try {
+            saveCacheToFile();
+        } catch (IOException e) {
+            log.warning(e.getMessage());
+        }
+    }
+
     void remove(String filePath) {
         File cacheFile = new File(cacheDirectory + "/" + filePath);
         try {

--- a/src/main/java/com/neko/cli/NekoCache.java
+++ b/src/main/java/com/neko/cli/NekoCache.java
@@ -1,0 +1,42 @@
+package com.neko.cli;
+
+import java.util.HashMap;
+
+/**
+ * Created by andyccs on 23/3/16.
+ */
+public class NekoCache {
+    private static final String CACHE_DATA_FILE = ".cache_data.json";
+
+    private HashMap<String, FileMetadata> caches = new HashMap<>();
+
+    public NekoCache(String cacheDirectory) {
+    }
+
+    public void loadCacheData() {
+
+    }
+
+    public void save(String filePath,
+                     long lastModified,
+                     long lastValidation,
+                     String text) {
+
+    }
+
+    public void remove(String filePath) {
+
+    }
+
+    public FileMetadata readMetadata(String filePath) {
+        return null;
+    }
+
+    public String read(String filePath, int offset, int length) {
+        return "";
+    }
+
+    public boolean exist(String filePath) {
+        return false;
+    }
+}

--- a/src/main/java/com/neko/msg/NekoAttribute.java
+++ b/src/main/java/com/neko/msg/NekoAttribute.java
@@ -10,9 +10,9 @@ public enum NekoAttribute {
     INTERVAL(3),
     TEXT(4),
     LENGTH(5),
-
     NUMBER(6),
-    ERROR(7);
+    ERROR(7),
+    LAST_MODIFIED(8);
 
     private static final Logger log = Logger.getLogger(NekoByteBuffer.class.getName());
 

--- a/src/main/java/com/neko/msg/NekoData.java
+++ b/src/main/java/com/neko/msg/NekoData.java
@@ -24,6 +24,8 @@ public class NekoData {
     private Integer length;
     @NekoFieldAttribute(attribute = NekoAttribute.NUMBER, type = NekoDataType.INTEGER)
     private Integer number;
+    @NekoFieldAttribute(attribute = NekoAttribute.LAST_MODIFIED, type = NekoDataType.STRING)
+    private String lastModified;
     @NekoFieldAttribute(attribute = NekoAttribute.ERROR, type = NekoDataType.STRING)
     private String error;
 
@@ -66,6 +68,10 @@ public class NekoData {
         return number;
     }
 
+    public String getLastModified() {
+        return lastModified;
+    }
+
     public String getError() {
         return error;
     }
@@ -100,6 +106,10 @@ public class NekoData {
 
     public void setNumber(Integer number) {
         this.number = number;
+    }
+
+    public void setLastModified(String lastModified) {
+        this.lastModified = lastModified;
     }
 
     public void setError(String error) {

--- a/src/main/java/com/neko/msg/NekoData.java
+++ b/src/main/java/com/neko/msg/NekoData.java
@@ -120,13 +120,14 @@ public class NekoData {
     public String toString() {
         return "NekoData{"
                 + "opcode=" + opcode
-                + ", path='" + path + '\''
+                + ", path='" + path + "'"
                 + ", offset=" + offset
                 + ", interval=" + interval
-                + ", text='" + text + '\''
+                + ", text='" + text + "'"
                 + ", length=" + length
                 + ", number=" + number
-                + ", error='" + error + '\''
+                + ", error='" + error + "'"
+                + ", last_modified='" + lastModified + "'"
                 + '}';
     }
 }

--- a/src/main/java/com/neko/msg/NekoDeserializer.java
+++ b/src/main/java/com/neko/msg/NekoDeserializer.java
@@ -49,6 +49,9 @@ public class NekoDeserializer {
                 case ERROR:
                     deserialized.setError(in.readString());
                     break;
+                case LAST_MODIFIED:
+                    deserialized.setLastModified(in.readString());
+                    break;
                 default:
                     throw new InputMismatchException("Unknown NekoAttribute");
             }

--- a/src/main/java/com/neko/msg/NekoOpcode.java
+++ b/src/main/java/com/neko/msg/NekoOpcode.java
@@ -10,7 +10,8 @@ public enum NekoOpcode {
     COPY(3),
     COUNT(4),
     RESULT(5),
-    ERROR(6);
+    ERROR(6),
+    LAST_MODIFIED(7);
 
     private static final Logger log = Logger.getLogger(NekoByteBuffer.class.getName());
 

--- a/src/main/java/com/neko/simulation/UnstableDatagramSocket.java
+++ b/src/main/java/com/neko/simulation/UnstableDatagramSocket.java
@@ -13,8 +13,8 @@ import java.util.logging.Logger;
 public class UnstableDatagramSocket extends DatagramSocket {
     private static final Logger log = Logger.getLogger(UnstableDatagramSocket.class.getName());
 
-    public final double DROP_RECEIVE_PROB = 0.5;
-    public final double DROP_SEND_PROB = 0.5;
+    public static final double DROP_RECEIVE_PROB = 0.5;
+    public static final double DROP_SEND_PROB = 0.5;
 
     public final Queue<Boolean> receiveSequence = new LinkedList<>();
     public final Queue<Boolean> sendSequence = new LinkedList<>();
@@ -33,44 +33,46 @@ public class UnstableDatagramSocket extends DatagramSocket {
      *      means:
      *          for send calls: [drop, drop, not drop, not drop, drop]
      */
-    public UnstableDatagramSocket(int port, String receiveSequence, String sendSequence) throws SocketException {
+    public UnstableDatagramSocket(int port, String receiveSequence, String sendSequence)
+            throws SocketException {
         super(port);
         addSequence(this.receiveSequence, receiveSequence);
         addSequence(this.sendSequence, sendSequence);
     }
 
     private void addSequence(Queue<Boolean> sequence, String sequenceString) {
-        if (sequence != null) {
-            for (char c : sequenceString.toCharArray()) {
-                if (c == '0')
-                    sequence.add(false);
-                else
-                    sequence.add(true);
+        if (sequence == null) {
+            return;
+        }
+
+        for (char c : sequenceString.toCharArray()) {
+            if (c == '0') {
+                sequence.add(false);
+            } else {
+                sequence.add(true);
             }
         }
     }
 
     @Override
-    public void send(DatagramPacket p) throws IOException {
+    public void send(DatagramPacket packet) throws IOException {
         if (dropSend()) {
             log.log(Level.ALL, "Drop send.");
             return;
-        }
-        else {
+        } else {
             log.log(Level.ALL, "Send.");
-            super.send(p);
+            super.send(packet);
         }
     }
 
     @Override
-    public void receive(DatagramPacket p) throws IOException {
+    public void receive(DatagramPacket packet) throws IOException {
         if (dropReceive()) {
             log.log(Level.ALL, "Drop receive.");
             return;
-        }
-        else {
+        } else {
             log.log(Level.ALL, "Receive.");
-            super.receive(p);
+            super.receive(packet);
         }
     }
 
@@ -80,14 +82,16 @@ public class UnstableDatagramSocket extends DatagramSocket {
     }
 
     private boolean dropSend() {
-        if (!sendSequence.isEmpty())
+        if (!sendSequence.isEmpty()) {
             return sendSequence.poll();
+        }
         return ran.nextDouble() < DROP_SEND_PROB;
     }
 
     private boolean dropReceive() {
-        if (!receiveSequence.isEmpty())
+        if (!receiveSequence.isEmpty()) {
             return receiveSequence.poll();
+        }
         return ran.nextDouble() < DROP_RECEIVE_PROB;
     }
 }


### PR DESCRIPTION
Refer to issue #15 

New feature:
- server can read all data in a file now
- server can only send back `last modified` of a file, without the data of a file
- client will cache all files under `.nekocache` directory
- client will create cache json config file in `/nekocache/.cache_data.json`
- client CLI can accept --fresh option to specify the freshness of a cache entry
